### PR TITLE
Fix NFS compatibility, remove database_version.txt, and improve unauthenticated access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.1.1] - 2026-03-31
+
+### Fixed
+
+- `check_dir` now uses an actual write test instead of `os.access`, fixing
+  false "Cannot write to directory" errors on NFS-mounted filesystems common
+  in HPC environments. Thanks to @talasjudit for the detailed report and
+  suggested fix. ([#32](https://github.com/MDU-PHL/mlstdb/issues/32))
+- `last-updated` field in scheme info JSON is now capped at `2024-12-31` when
+  running with `--no-auth`, accurately reflecting the data cutoff date for
+  unauthenticated access. ([#31](https://github.com/MDU-PHL/mlstdb/issues/31))
+- Removed the legacy `database_version.txt` file from the scheme directory.
+  Scheme metadata is now stored exclusively in `{scheme}_info.json`.
+  ([#11](https://github.com/MDU-PHL/mlstdb/issues/11))
+
 ## [1.1.0] - 2026-03-24
 
 ### Added

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,7 +96,6 @@ pubmlst/
 ├── klebsiella/
 │   ├── klebsiella.txt          # ST profiles
 │   ├── klebsiella_info.json    # Scheme metadata
-│   ├── database_version.txt    # Database version number
 │   ├── gapA.tfa                # Allele sequences
 │   ├── infB.tfa
 │   └── ...

--- a/docs/usage/update.md
+++ b/docs/usage/update.md
@@ -98,7 +98,6 @@ For each scheme, `mlstdb update` creates a directory containing:
 | `<scheme>.txt` | ST profile definitions (tab-delimited) |
 | `<locus>.tfa` | Allele sequences for each locus (FASTA) |
 | `<scheme>_info.json` | Metadata: source, download date, locus count |
-| `database_version.txt` | Database version number |
 
 ### Profile file format
 

--- a/src/mlstdb/__about__.py
+++ b/src/mlstdb/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present Himal Shrestha <himal2007@duck.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/src/mlstdb/core/config.py
+++ b/src/mlstdb/core/config.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import os
 from typing import Dict
 
 # Constants
@@ -30,5 +29,11 @@ def check_dir(directory: str) -> None:
     path = Path(directory)
     if not path.exists():
         path.mkdir(parents=True)
-    if not (path.is_dir() and os.access(directory, os.W_OK)):
+    if not path.is_dir():
+        raise PermissionError(f"Cannot write to directory: {directory}")
+    try:
+        test_file = path / ".write_test"
+        test_file.touch()
+        test_file.unlink()
+    except OSError:
         raise PermissionError(f"Cannot write to directory: {directory}")

--- a/src/mlstdb/core/download.py
+++ b/src/mlstdb/core/download.py
@@ -155,6 +155,19 @@ def get_mlst_files(url:  str, directory: str, client_key: str, client_secret: st
             last_added = 'No version information available'
         
         last_updated = mlst_scheme.get('last_updated', last_added)
+
+        # Unauthenticated access only covers data up to 2024-12-31.
+        # Cap any reported last_updated to that date so the stored metadata
+        # is not misleading.
+        _NO_AUTH_CUTOFF = '2024-12-31'
+        if no_auth and last_updated:
+            try:
+                if (datetime.strptime(last_updated, '%Y-%m-%d')
+                        > datetime.strptime(_NO_AUTH_CUTOFF, '%Y-%m-%d')):
+                    last_updated = _NO_AUTH_CUTOFF
+            except ValueError:
+                pass  # non-standard date format — leave unchanged
+
         locus_count = mlst_scheme.get('locus_count', len(mlst_scheme.get('loci', [])))
         download_date = datetime.now().strftime('%Y-%m-%d')
 
@@ -186,11 +199,10 @@ def get_mlst_files(url:  str, directory: str, client_key: str, client_secret: st
         if verbose:
             info(f"Scheme info saved to {scheme_info_path}")
 
-        # Keep database_version.txt for backwards compatibility
-        # This can be removed in a future version
+        # Remove legacy database_version.txt if present (superseded by scheme_info.json)
         db_version_path = os.path.join(directory, 'database_version.txt')
-        with open(db_version_path, 'w') as version_file:
-            version_file.write(f"{last_updated}\n")
+        if os.path.exists(db_version_path):
+            os.remove(db_version_path)
 
         # Download loci
         loci_iter = tqdm(mlst_scheme['loci'], desc="Downloading loci", unit="locus") if show_progress else mlst_scheme['loci']

--- a/tests/test_core/test_config.py
+++ b/tests/test_core/test_config.py
@@ -1,0 +1,48 @@
+import pytest
+import stat
+from unittest.mock import patch
+from pathlib import Path
+from mlstdb.core.config import check_dir
+
+
+def test_check_dir_creates_missing_directory(tmp_path):
+    """check_dir creates the directory when it does not exist."""
+    new_dir = tmp_path / "new" / "nested"
+    assert not new_dir.exists()
+    check_dir(str(new_dir))
+    assert new_dir.is_dir()
+
+
+def test_check_dir_accepts_existing_writable_directory(tmp_path):
+    """check_dir succeeds silently on an existing writable directory."""
+    check_dir(str(tmp_path))  # should not raise
+
+
+def test_check_dir_raises_on_unwritable_directory(tmp_path):
+    """check_dir raises PermissionError when the directory is not writable."""
+    ro_dir = tmp_path / "readonly"
+    ro_dir.mkdir()
+    ro_dir.chmod(stat.S_IRUSR | stat.S_IXUSR)  # r-x, no write
+    try:
+        with pytest.raises(PermissionError, match="Cannot write to directory"):
+            check_dir(str(ro_dir))
+    finally:
+        # Restore permissions so tmp_path cleanup can remove the directory.
+        ro_dir.chmod(stat.S_IRWXU)
+
+
+def test_check_dir_raises_when_write_test_fails(tmp_path):
+    """check_dir raises PermissionError when the actual write test raises OSError.
+
+    This tests the NFS / network-filesystem scenario where os.access would
+    return True but a real write still fails.
+    """
+    with patch("pathlib.Path.touch", side_effect=OSError("NFS write denied")):
+        with pytest.raises(PermissionError, match="Cannot write to directory"):
+            check_dir(str(tmp_path))
+
+
+def test_check_dir_cleans_up_write_test_file(tmp_path):
+    """check_dir leaves no .write_test artefact behind after a successful check."""
+    check_dir(str(tmp_path))
+    assert not (tmp_path / ".write_test").exists()


### PR DESCRIPTION
This release addresses filesystem compatibility issues and improves data accuracy for unauthenticated users. The problematic `database_version.txt` file has been removed, and the `check_dir` function now works reliably on NFS-mounted filesystems by performing an actual write test instead of relying on the unreliable `os.access()` check.

When using `--no-auth` access, the tool now correctly sets the `last-updated` field to 2024-12-31 to reflect the actual data availability window, preventing confusion about what schemes are accessible.

### What's changed

**Bug fixes**

- `check_dir` now uses an actual write test instead of `os.access()`, fixing failures on NFS-mounted filesystems (#32). Thank you @talasjudit for reporting and suggesting the fix!
- `last-updated` field is now set to 2024-12-31 for unauthenticated access to accurately reflect data availability (#31)

**Removals**

- Removed the legacy `database_version.txt` file from scheme directories, no longer needed (#11)

**Documentation**

- Updated getting started guide and usage documentation to reflect removal of `database_version.txt`

**Tests**

- Added unit tests for `check_dir` to ensure it behaves correctly across different scenarios.

### Closes

- #31 — Set `last-updated` to 2024-12-31 for unauthenticated access to reflect data availability
- #11 — Remove the need for `database_version.txt` entirely
- #32 — `check_dir` fails on NFS filesystems
