### PR TITLE
Add Personal API Key support (pubMLST) and improve error handling for BIGSdb authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,29 @@
 # Changelog
 
+## [1.2.0] - 2026-05-22
+
+### Added
+
+- Personal API key support (BIGSdb ≥ v1.53.0): `mlstdb connect --api-key` registers a key generated from your BIGSdb profile page. The key is stored in `~/.config/mlstdb/api_keys` (`0600`) and used automatically by `update` and `fetch` in preference to OAuth tokens.
+- New `setup_api_key()` and `retrieve_api_key()` functions in `mlstdb.core.auth` for storing and retrieving personal API keys.
+- `create_session()` in `mlstdb.core.download` now accepts an `api_key` parameter; when set it creates a plain `requests.Session` with the `X-API-Key` header.
+- `remove_db_credentials()` now also removes stored API keys when purging a site's credentials.
+
+### Fixed
+
+- `TypeError: argument of type 'NoneType' is not iterable` in `mlstdb connect --db pubmlst` on Rocky Linux and WSL2 ([#35](https://github.com/MDU-PHL/mlstdb/issues/35)). Root cause: rauth 0.7.3 `_parse_optional_params` calls `req_kwargs.get('params')` without a default, raising `TypeError` when `params` is absent from request kwargs. Fixed by passing `params={}` to every bare `OAuth1Session.get()` call across `auth.py` and `download.py`.
+- Unsafe `r.json()['message']` error parsing in `register_tokens()` and throughout the download pipeline replaced by a new `_parse_error_message()` helper, which gracefully handles non-JSON responses (HTML error pages, empty bodies) returned by BIGSdb on
+  HTTPS redirects or proxy errors.
+- `mlstdb connect` now prints actionable clock-sync instructions when the OAuth request token step fails with a `timestamp more than 600 seconds` error.
+
+
 ## [1.1.1] - 2026-03-31
 
 ### Fixed
 
-- `check_dir` now uses an actual write test instead of `os.access`, fixing
-  false "Cannot write to directory" errors on NFS-mounted filesystems common
-  in HPC environments. Thanks to @talasjudit for the detailed report and
-  suggested fix. ([#32](https://github.com/MDU-PHL/mlstdb/issues/32))
-- `last-updated` field in scheme info JSON is now capped at `2024-12-31` when
-  running with `--no-auth`, accurately reflecting the data cutoff date for
-  unauthenticated access. ([#31](https://github.com/MDU-PHL/mlstdb/issues/31))
-- Removed the legacy `database_version.txt` file from the scheme directory.
-  Scheme metadata is now stored exclusively in `{scheme}_info.json`.
-  ([#11](https://github.com/MDU-PHL/mlstdb/issues/11))
+- `check_dir` now uses an actual write test instead of `os.access`, fixing false "Cannot write to directory" errors on NFS-mounted filesystems common in HPC environments. Thanks to @talasjudit for the detailed report and suggested fix. ([#32](https://github.com/MDU-PHL/mlstdb/issues/32))
+- `last-updated` field in scheme info JSON is now capped at `2024-12-31` when running with `--no-auth`, accurately reflecting the data cutoff date for unauthenticated access. ([#31](https://github.com/MDU-PHL/mlstdb/issues/31))
+- Removed the legacy `database_version.txt` file from the scheme directory. Scheme metadata is now stored exclusively in `{scheme}_info.json`. ([#11](https://github.com/MDU-PHL/mlstdb/issues/11))
 
 ## [1.1.0] - 2026-03-24
 
@@ -97,6 +107,7 @@
 [0.1.7]: https://github.com/MDU-PHL/mlstdb/releases/tag/v0.1.7
 [1.1.0]: https://github.com/MDU-PHL/mlstdb/releases/tag/v1.1.0
 [1.1.1]: https://github.com/MDU-PHL/mlstdb/releases/tag/v1.1.1
+[1.2.0]: https://github.com/MDU-PHL/mlstdb/releases/tag/v1.2.0
 [#11]: https://github.com/MDU-PHL/mlstdb/issues/11
 [#16]: https://github.com/MDU-PHL/mlstdb/issues/16
 [#20]: https://github.com/MDU-PHL/mlstdb/issues/20

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,29 +22,45 @@ mlstdb --version
 
 ## Step 2: Register with the databases
 
-Before downloading any schemes, you need to register your OAuth credentials with PubMLST and/or Pasteur. This is a **one-time setup**. Your credentials are saved locally and reused for future updates.
+Before downloading any schemes, you need to register your credentials with PubMLST and/or Pasteur. This is a **one-time setup**. Your credentials are saved locally and reused for future updates.
 
-### Connect to PubMLST
+Two methods are available — choose the one that suits your setup:
+
+---
+
+### Option A: Personal API Key *(recommended for PubMLST)*
+
+BIGSdb v1.53.0 (PubMLST since May 2026) supports personal API keys — a simpler alternative to OAuth with no browser step required.
+
+```sh
+mlstdb connect --db pubmlst --api-key
+```
+
+You will be prompted to paste your API key (generate one from your PubMLST profile page under **API keys**). The key is saved to `~/.config/mlstdb/api_keys`.
+
+!!! tip "Where do I get my API key?"
+    See the [Connect guide](usage/connect.md#obtaining-a-personal-api-key) for step-by-step instructions.
+
+---
+
+### Option B: OAuth *(required for Pasteur or older BIGSdb instances)*
 
 ```sh
 mlstdb connect --db pubmlst
-```
-
-### Connect to Pasteur
-
-```sh
 mlstdb connect --db pasteur
 ```
 
 Each `connect` command will:
 
 1. Ask for your **Client ID** (24 characters) and **Client Secret** (42 characters)
-2. Open an authorisation URL, visit it in your browser
+2. Open an authorisation URL — visit it in your browser
 3. Ask you to paste the **verification code** from the website
 4. Save all tokens securely to `~/.config/mlstdb/`
 
 !!! tip "Where do I get my Client ID and Client Secret?"
-    See the [Connect guide](usage/connect.md#obtaining-client-credentials) for step-by-step instructions on registering with PubMLST and Pasteur.
+    See the [Connect guide](usage/connect.md#oauth-legacy) for step-by-step instructions on registering with PubMLST and Pasteur.
+
+---
 
 !!! info
     If you've already connected before, `mlstdb connect` will test your existing credentials and skip re-registration if they're still valid.

--- a/docs/usage/connect.md
+++ b/docs/usage/connect.md
@@ -1,12 +1,23 @@
 # Connect
 
-The `connect` command registers your OAuth credentials with PubMLST or Pasteur databases. This is a **one-time setup** per database, credentials are saved locally and reused automatically.
+The `connect` command registers your credentials with PubMLST or Pasteur databases. This is a **one-time setup** per database. Credentials are saved locally and reused automatically.
+
+Two authentication methods are supported:
+
+| Method | When to use |
+|--------|-------------|
+| **Personal API Key** *(recommended)* | BIGSdb ≥ v1.53.0 (PubMLST since May 2026). Simpler setup, no OAuth flow, no browser required. Note, only available for PubMLST. |
+| **OAuth** *(legacy)* | All BIGSdb versions. Required for Pasteur or any older instance. |
 
 ---
 
 ## Basic Usage
 
 ```sh
+# Personal API Key (recommended for PubMLST)
+mlstdb connect --db pubmlst --api-key
+
+# OAuth (legacy, or for Pasteur)
 mlstdb connect --db pubmlst
 mlstdb connect --db pasteur
 ```
@@ -20,12 +31,54 @@ If you omit `--db`, you'll be prompted to choose.
 | Option | Description |
 |--------|-------------|
 | `--db`, `-d` | Database to connect to: `pubmlst` or `pasteur` |
+| `--api-key` | Register using a personal API key instead of OAuth (BIGSdb ≥ v1.53.0) |
 | `--verbose`, `-v` | Show detailed debug output |
 | `-h`, `--help` | Show help message |
 
 ---
 
-## Obtaining Client Credentials
+## Personal API Key
+
+BIGSdb v1.53.0 introduced personal API keys as a simpler alternative to OAuth. A single key is generated from your BIGSdb user profile and passed via the `X-API-Key` request header. There is no browser step, no verification code, and no OAuth token expiry.
+
+### Obtaining a Personal API Key
+
+#### PubMLST
+
+1. Go to [https://pubmlst.org/bigsdb](https://pubmlst.org/bigsdb) and log in
+2. Open your **My Account** (top-right menu)
+3. Scroll to the **API keys** section and generate a new key for MLST database access (if not already generated).
+4. Copy the key.
+
+#### Pasteur
+
+Personal API keys require BIGSdb ≥ v1.53.0. Check with the Pasteur team whether their instance has been upgraded before using `--api-key` for Pasteur.
+
+### Registering your API Key
+
+```sh
+mlstdb connect --db pubmlst --api-key
+```
+
+You will be prompted:
+
+```
+Please enter your personal API key (from your BIGSdb profile page):
+API Key: **********************
+```
+
+The key is saved to `~/.config/mlstdb/api_keys` with `0600` permissions and used automatically by all subsequent `mlstdb update` and `mlstdb fetch` calls.
+
+!!! tip
+    You can regenerate your key at any time from your BIGSdb profile. Run `mlstdb connect --db pubmlst --api-key` again to update the stored key.
+
+---
+
+## OAuth (Legacy)
+
+Use OAuth if you are on an older BIGSdb instance or need access to private data or submission endpoints (API keys only cover public data reads).
+
+### Obtaining Client Credentials
 
 Before running `mlstdb connect`, you need to register as an API client on each database platform to get your **Client ID** and **Client Secret**.
 
@@ -53,9 +106,15 @@ Before running `mlstdb connect`, you need to register as an API client on each d
 
 ---
 
-## What happens during connect
+## What Happens During `connect`
 
-When you run `mlstdb connect`, the following OAuth flow occurs:
+### Personal API Key flow
+
+1. **You provide** your personal API key (from your BIGSdb profile)
+2. **mlstdb** tests the key against the database API
+3. **Key is saved** to `~/.config/mlstdb/api_keys`
+
+### OAuth flow
 
 1. **You provide** your Client ID and Client Secret
 2. **mlstdb** requests a temporary token from the API
@@ -67,9 +126,10 @@ When you run `mlstdb connect`, the following OAuth flow occurs:
 
 ```
 ~/.config/mlstdb/
-├── client_credentials    # Your Client ID and Secret
+├── api_keys              # Personal API key (BIGSdb ≥ v1.53.0)
+├── client_credentials    # OAuth Client ID and Secret
 ├── access_tokens         # OAuth access tokens
-└── session_tokens        # Session tokens (used for API calls)
+└── session_tokens        # OAuth session tokens (used for API calls)
 ```
 
 !!! note "Security"
@@ -78,7 +138,19 @@ When you run `mlstdb connect`, the following OAuth flow occurs:
 
 ## Re-connecting
 
-If your credentials expire or become invalid, `mlstdb connect` will detect this:
+### Personal API Key
+
+If your key is revoked or regenerated on the BIGSdb side, re-run:
+
+```sh
+mlstdb connect --db pubmlst --api-key
+```
+
+You will be prompted whether to replace the existing key.
+
+### OAuth
+
+If your OAuth credentials expire or become invalid, `mlstdb connect` will detect this:
 
 ```sh
 mlstdb connect --db pubmlst

--- a/docs/usage/overview.md
+++ b/docs/usage/overview.md
@@ -44,9 +44,13 @@
 
 ### `mlstdb connect` — Register credentials
 
-Sets up OAuth authentication with PubMLST or Pasteur. Run once per database.
+Sets up authentication with PubMLST or Pasteur. Run once per database.
 
 ```sh
+# Recommended: personal API key (BIGSdb ≥ v1.53.0, e.g. PubMLST)
+mlstdb connect --db pubmlst --api-key
+
+# Legacy OAuth (all BIGSdb versions, required for Pasteur)
 mlstdb connect --db pubmlst
 mlstdb connect --db pasteur
 ```

--- a/docs/usage/update.md
+++ b/docs/usage/update.md
@@ -21,11 +21,16 @@ By default, this uses the built-in curated list of ~170 MLST schemes from both P
 | `--input`, `-i` | Path to custom scheme list file | Built-in `mlst_schemes_all.tab` |
 | `--directory`, `-d` | Output directory for scheme data | `pubmlst` |
 | `--blast-directory`, `-b` | Output directory for BLAST database | `blast` |
-| `--no-auth` | Skip OAuth; use unauthenticated access | Off |
+| `--no-auth` | Skip authentication; use unauthenticated access | Off |
 | `--resume`, `-r` | Skip already-downloaded schemes | Off |
 | `--threads`, `-t` | Parallel download threads (max recommended: 4) | `1` |
 | `--verbose`, `-v` | Show detailed debug output | Off |
 | `-h`, `--help` | Show help message | |
+
+!!! tip "Authentication"
+    `mlstdb update` automatically uses a **personal API key** if one is stored
+    (set up via `mlstdb connect --api-key`), falling back to OAuth tokens if not.
+    Use `--no-auth` only when neither is available and you only need public data.
 
 ---
 

--- a/src/mlstdb/__about__.py
+++ b/src/mlstdb/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present Himal Shrestha <himal2007@duck.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-__version__ = "1.1.1"
+__version__ = "1.2.0"

--- a/src/mlstdb/cli/__init__.py
+++ b/src/mlstdb/cli/__init__.py
@@ -19,8 +19,9 @@ def mlstdb():
     \b
     Recommended workflow:
     1. mlstdb connect --db pubmlst/pasteur    # Register credentials
-    2. mlstdb update --db pubmlst             # Update database
-    3. mlstdb fetch                           # [ADVANCED] Explore custom schemes
+    2. mlstdb update                          # Update database
+    3. mlstdb purge                           # Remove contaminated/erroneous profiles (optional)
+    4. mlstdb fetch                           # [ADVANCED] Explore custom schemes
     
     Most users only need to use 'connect' and 'update' commands.
     

--- a/src/mlstdb/cli/connect.py
+++ b/src/mlstdb/cli/connect.py
@@ -1,17 +1,19 @@
 import click
 import configparser
-from mlstdb.core.auth import register_tokens, test_connection
+from mlstdb.core.auth import register_tokens, test_connection, setup_api_key, retrieve_api_key
 from mlstdb.core.config import get_config_dir
 from mlstdb.utils import error, success, info
 
 
 @click.command()
 @click.help_option('-h', '--help')
-@click.option('--db', '-d', type=click.Choice(['pubmlst', 'pasteur']), 
+@click.option('--db', '-d', type=click.Choice(['pubmlst', 'pasteur']),
               help='Database to use (pubmlst or pasteur)')
-@click.option('--verbose', '-v', is_flag=True, 
+@click.option('--api-key', 'use_api_key', is_flag=True, default=False,
+              help='Register using a personal API key instead of OAuth (BIGSdb ≥ v1.53.0)')
+@click.option('--verbose', '-v', is_flag=True,
               help='Enable verbose logging for debugging')
-def connect(db, verbose):
+def connect(db, use_api_key, verbose):
     """Initial Database Registration and Setup
     
     Establishes connection with PubMLST or Pasteur databases by registering
@@ -22,12 +24,43 @@ def connect(db, verbose):
     try:
         # If db is not provided, prompt for it
         if not db:
-            db = click. prompt(
+            db = click.prompt(
                 "Which database would you like to connect to?",
                 type=click.Choice(['pubmlst', 'pasteur']),
                 default='pubmlst'
             )
-        
+
+        if use_api_key:
+            # --- API key registration path (BIGSdb ≥ v1.53.0) ---
+            existing_key = retrieve_api_key(db)
+            if existing_key:
+                click.secho(f"\n✓ API key found for {db}", fg="green")
+                info("\nVerifying existing API key...")
+                if test_connection(db, verbose=verbose, api_key=existing_key):
+                    success(f"\n✓ API key for {db} is valid!")
+                    info("\nYou can now use 'mlstdb update' to update/download your database.")
+                    return
+                else:
+                    error(f"\n✗ API key test failed for {db}")
+                    if not click.confirm(f"\nDo you want to replace the API key for {db}?",
+                                        default=True):
+                        error("\nmlstdb not connected. Please re-register when ready.")
+                        raise SystemExit(1)
+
+            saved_key = setup_api_key(db)
+            info("\nVerifying new API key...")
+            if test_connection(db, verbose=verbose, api_key=saved_key):
+                success(f"\n✓ Successfully connected to {db} using API key!")
+                info("\nNext steps:")
+                info("  1. Use 'mlstdb update' to update/download MLST schemes")
+                info("  2. Or use 'mlstdb fetch' for advanced schema exploration")
+            else:
+                error(f"\n✗ Connection test failed after saving API key")
+                info("Please check your API key and try again.")
+                raise SystemExit(1)
+            return
+
+        # --- OAuth registration path ---
         config_dir = get_config_dir()
         client_creds_file = config_dir / "client_credentials"
         session_tokens_file = config_dir / "session_tokens"

--- a/src/mlstdb/cli/fetch.py
+++ b/src/mlstdb/cli/fetch.py
@@ -6,7 +6,7 @@ from tqdm import tqdm
 import configparser
 import sys
 import os
-from mlstdb.core.auth import register_tokens, setup_client_credentials, remove_db_credentials
+from mlstdb.core.auth import register_tokens, setup_client_credentials, remove_db_credentials, retrieve_api_key
 from mlstdb.core.download import (fetch_resources, get_matching_schemes, create_session,
                                 sanitise_output, clear_file, 
                                 load_processed_databases,save_processed_database, load_scheme_uris)
@@ -87,41 +87,52 @@ def fetch(db, exclude, match, scheme_uris, filter, resume, no_auth, threads, ver
             info("Using unauthenticated access (no OAuth)")
             http_session = create_session(no_auth=True)
         else:
-            # Get client credentials
-            config_dir = get_config_dir()
-            client_creds_file = config_dir / "client_credentials"
-            session_tokens_file = config_dir / "session_tokens"
+            # Check for API key first (BIGSdb ≥ v1.53.0)
+            api_key = retrieve_api_key(db)
+            if api_key:
+                info("Using API key authentication")
+                http_session = create_session(api_key=api_key)
+                client_key = None
+                client_secret = None
+                session_token = None
+                session_secret = None
+            else:
+                # Fall back to OAuth
+                # Get client credentials
+                config_dir = get_config_dir()
+                client_creds_file = config_dir / "client_credentials"
+                session_tokens_file = config_dir / "session_tokens"
 
-            # Check if credentials exist, if not setup
-            if not client_creds_file.exists() or not session_tokens_file.exists():
-                register_tokens(db)
+                # Check if credentials exist, if not setup
+                if not client_creds_file.exists() or not session_tokens_file.exists():
+                    register_tokens(db)
 
-            # Get credentials
-            config = configparser.ConfigParser(interpolation=None)
-            
-            # Read client credentials
-            config.read(client_creds_file)
-            if not config.has_section(db):
-                error(f"No client credentials found for {db}")
-                register_tokens(db)
+                # Get credentials
+                config = configparser.ConfigParser(interpolation=None)
+
+                # Read client credentials
                 config.read(client_creds_file)
-            
-            client_key = config[db]["client_id"]
-            client_secret = config[db]["client_secret"]
+                if not config.has_section(db):
+                    error(f"No client credentials found for {db}")
+                    register_tokens(db)
+                    config.read(client_creds_file)
 
-            # Read session tokens
-            config.read(session_tokens_file)
-            if not config.has_section(db):
-                error(f"No session token found for {db}")
-                register_tokens(db)
+                client_key = config[db]["client_id"]
+                client_secret = config[db]["client_secret"]
+
+                # Read session tokens
                 config.read(session_tokens_file)
-            
-            session_token = config[db]["token"]
-            session_secret = config[db]["secret"]
+                if not config.has_section(db):
+                    error(f"No session token found for {db}")
+                    register_tokens(db)
+                    config.read(session_tokens_file)
 
-            # Create a single reusable OAuth session
-            http_session = create_session(client_key, client_secret, 
-                                          session_token, session_secret)
+                session_token = config[db]["token"]
+                session_secret = config[db]["secret"]
+
+                # Create a single reusable OAuth session
+                http_session = create_session(client_key, client_secret,
+                                              session_token, session_secret)
 
         output_file = f"mlst_schemes_{db}.tab"
         processed_file = f"processed_dbs_{db}.tab"

--- a/src/mlstdb/cli/update.py
+++ b/src/mlstdb/cli/update.py
@@ -4,7 +4,7 @@ import importlib.resources
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from mlstdb.core.auth import get_client_credentials, retrieve_session_token
+from mlstdb.core.auth import get_client_credentials, retrieve_session_token, retrieve_api_key
 from mlstdb.core.download import get_mlst_files, create_blast_db, create_session, remove_incomplete_schemes
 from mlstdb.core.config import check_dir
 from mlstdb.utils import error, success, info
@@ -93,12 +93,19 @@ def update(input: str, directory: str, blast_directory: str, verbose: bool, no_a
         # Build reusable sessions per database type
         sessions = {}  # db_type -> session
         credentials = {}  # db_type -> (client_key, client_secret, session_token, session_secret)
+        api_keys = {}  # db_type -> api_key string (when API key auth is used)
 
         if no_auth:
             sessions['no_auth'] = create_session(no_auth=True)
         else:
             db_types_needed = set(entry[0].lower() for entry in scheme_entries)
             for db_type in db_types_needed:
+                api_key = retrieve_api_key(db_type)
+                if api_key:
+                    api_keys[db_type] = api_key
+                    credentials[db_type] = (None, None, None, None)
+                    sessions[db_type] = create_session(api_key=api_key)
+                    continue
                 try:
                     client_key, client_secret = get_client_credentials(db_type)
                     session_token, session_secret = retrieve_session_token(db_type)
@@ -127,6 +134,7 @@ def update(input: str, directory: str, blast_directory: str, verbose: bool, no_a
             session = sessions[db_key]
             creds = credentials.get(database.lower(), (None, None, None, None))
             client_key, client_secret, session_token, session_secret = creds
+            entry_api_key = api_keys.get(database.lower())
 
             scheme_dir = Path(directory) / scheme
             check_dir(str(scheme_dir))
@@ -135,7 +143,7 @@ def update(input: str, directory: str, blast_directory: str, verbose: bool, no_a
                 get_mlst_files(url, str(scheme_dir), client_key, client_secret,
                                session_token, session_secret, scheme, verbose=verbose,
                                no_auth=no_auth, session=session,
-                               show_progress=not parallel)
+                               show_progress=not parallel, api_key=entry_api_key)
                 return ('ok', scheme, database)
             except Exception as e:
                 return ('error', scheme, database, e)

--- a/src/mlstdb/core/auth.py
+++ b/src/mlstdb/core/auth.py
@@ -71,6 +71,18 @@ def retrieve_api_key(site: str) -> Optional[str]:
     return None
 
 
+def _parse_error_message(response) -> str:
+    """Safely extract an error message from a failed API response."""
+    try:
+        data = response.json()
+        if isinstance(data, dict):
+            return data.get("message", f"HTTP {response.status_code}")
+        return f"HTTP {response.status_code}"
+    except Exception:
+        text = response.text[:200] if response.text else "(empty response)"
+        return f"HTTP {response.status_code} — {text}"
+
+
 def register_tokens(db: str):
     """Setup authentication tokens by registering with the service."""
     info(f"\nNo tokens found for {db}. Starting registration process...")
@@ -95,7 +107,16 @@ def register_tokens(db: str):
         headers={"User-Agent": f"mlstdb/{__version__}"}
     )
     if r.status_code != 200:
-        error(f"Failed to get request token: {r.json()['message']}")
+        msg = _parse_error_message(r)
+        if "timestamp" in msg.lower() or "600 seconds" in msg.lower():
+            error(
+                f"Failed to get request token: {msg}\n"
+                "  This is a clock synchronisation issue.\n"
+                "  On WSL/Linux, try:  sudo hwclock -s\n"
+                "  On WSL2, try:       sudo ntpdate time.windows.com"
+            )
+        else:
+            error(f"Failed to get request token: {msg}")
         sys.exit(1)
     
     request_token = r.json()["oauth_token"]
@@ -120,7 +141,7 @@ def register_tokens(db: str):
     )
     
     if r.status_code != 200:
-        error(f"Failed to get access token: {r.json()['message']}")
+        error(f"Failed to get access token: {_parse_error_message(r)}")
         sys.exit(1)
         
     access_token = r. json()["oauth_token"]
@@ -147,11 +168,12 @@ def register_tokens(db: str):
         access_token=access_token,
         access_token_secret=access_secret
     )
-    
-    r = session.get(url, headers={"User-Agent": f"mlstdb/{__version__}"})
-    
+    session.headers.update({"User-Agent": f"mlstdb/{__version__}"})
+
+    r = session.get(url, params={})
+
     if r.status_code != 200:
-        error(f"Failed to get session token: {r.json()['message']}")
+        error(f"Failed to get session token: {_parse_error_message(r)}")
         sys.exit(1)
         
     token = r.json()["oauth_token"]
@@ -292,7 +314,7 @@ def test_connection(db: str, verbose: bool = False, api_key: Optional[str] = Non
         if verbose:
             info(f"\nRequesting:  {test_url}")
 
-        response = session.get(test_url)
+        response = session.get(test_url, params={})
         
         if verbose:
             info(f"\nResponse status code: {response.status_code}")
@@ -322,7 +344,7 @@ def test_connection(db: str, verbose: bool = False, api_key: Optional[str] = Non
                     access_token_secret=session_secret,
                 )
                 session.headers. update({"User-Agent": f"mlstdb/{__version__}"})
-                response = session.get(test_url)
+                response = session.get(test_url, params={})
                 
                 if response. status_code == 200:
                     success("Connection successful after token refresh!")
@@ -395,7 +417,7 @@ def refresh_session_token(db:  str, client_key: str, client_secret: str, verbose
         if verbose:
             info(f"Requesting new session token from:  {url_session}")
         
-        r = session_request.get(url_session)
+        r = session_request.get(url_session, params={})
         
         if r.status_code == 200:
             new_token = r.json()["oauth_token"]

--- a/src/mlstdb/core/auth.py
+++ b/src/mlstdb/core/auth.py
@@ -2,6 +2,7 @@ import configparser
 import click
 import os
 import sys
+import requests
 from pathlib import Path
 from typing import Tuple, Optional
 from rauth import OAuth1Service, OAuth1Session
@@ -36,6 +37,39 @@ def setup_client_credentials(site: str) -> Tuple[str, str]:
         config.write(configfile)
     success(f"\nClient credentials saved to {file_path}")
     return client_id, client_secret
+
+
+def setup_api_key(site: str) -> str:
+    """Prompt for and save a personal API key (BIGSdb ≥ v1.53.0)."""
+    config = configparser.ConfigParser(interpolation=None)
+    file_path = get_config_dir() / "api_keys"
+    if file_path.exists():
+        config.read(file_path)
+
+    info("\nPlease enter your personal API key (from your BIGSdb profile page):")
+    api_key = click.prompt("API Key", type=str).strip()
+    while not api_key:
+        error("API key cannot be empty")
+        api_key = click.prompt("API Key", type=str).strip()
+
+    config[site] = {"api_key": api_key}
+    fd = os.open(file_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as configfile:
+        config.write(configfile)
+    success(f"\nAPI key saved to {file_path}")
+    return api_key
+
+
+def retrieve_api_key(site: str) -> Optional[str]:
+    """Return the stored personal API key for *site*, or None if not found."""
+    config = configparser.ConfigParser(interpolation=None)
+    file_path = get_config_dir() / "api_keys"
+    if file_path.is_file():
+        config.read(file_path)
+        if config.has_section(site):
+            return config[site].get("api_key")
+    return None
+
 
 def register_tokens(db: str):
     """Setup authentication tokens by registering with the service."""
@@ -162,7 +196,7 @@ def get_client_credentials(key_name: str) -> Tuple[str, str]:
 
 def remove_db_credentials(config_dir: Path, db: str) -> None:
     """Remove credentials for specific database while preserving others."""
-    for file_name in ["client_credentials", "session_tokens", "access_tokens"]:
+    for file_name in ["client_credentials", "session_tokens", "access_tokens", "api_keys"]:
         file_path = config_dir / file_name
         if file_path.exists():
             config = configparser.ConfigParser(interpolation=None)
@@ -186,33 +220,65 @@ def retrieve_session_token(key_name: str) -> Tuple[str, str]:
     
     return None, None
 
-def test_connection(db: str, verbose: bool = False) -> bool:
-    """Test if the connection to the database is valid. 
-    
+def test_connection(db: str, verbose: bool = False, api_key: Optional[str] = None) -> bool:
+    """Test if the connection to the database is valid.
+
     Args:
         db: Database name ('pubmlst' or 'pasteur')
         verbose: If True, display JSON payload from test URI
-        
+        api_key: Optional personal API key (BIGSdb ≥ v1.53.0)
+
     Returns:
         True if connection is valid, False otherwise
     """
     try:
-        # Get client credentials
-        client_id, client_secret = get_client_credentials(db)
-        
-        # Get session tokens
-        session_token, session_secret = retrieve_session_token(db)
-        
-        if not session_token or not session_secret:
-            return False
-        
         # Test URL - using the database info endpoint
         test_url = f"{BASE_API[db]}/db/{DB_MAPPING[db]}/schemes"
-        
+
         info(f"\nTesting connection to {db}...")
         info(f"Using test database:  {DB_MAPPING[db]}")
+
+        if api_key:
+            # API key auth path (BIGSdb ≥ v1.53.0)
+            session = requests.Session()
+            session.headers.update({
+                "User-Agent": f"mlstdb/{__version__}",
+                "X-API-Key": api_key,
+            })
+            if verbose:
+                info(f"\nRequesting:  {test_url}")
+            response = session.get(test_url)
+            if verbose:
+                info(f"\nResponse status code: {response.status_code}")
+                if response.status_code == 200:
+                    try:
+                        import json as json_module
+                        info("\nJSON payload received:")
+                        click.echo(json_module.dumps(response.json(), indent=2))
+                    except Exception as e:
+                        error(f"Could not parse JSON response: {e}")
+            if response.status_code == 200:
+                return True
+            elif response.status_code == 401:
+                error("\nAPI key rejected (401). The key may be revoked or invalid.")
+                info("Run 'mlstdb connect --api-key' to save a new API key.")
+                return False
+            else:
+                error(f"\nConnection test failed with status code: {response.status_code}")
+                return False
+
+        # OAuth path
         info("\nPlease ensure you are registered to this database.")
-        
+
+        # Get client credentials
+        client_id, client_secret = get_client_credentials(db)
+
+        # Get session tokens
+        session_token, session_secret = retrieve_session_token(db)
+
+        if not session_token or not session_secret:
+            return False
+
         # Create OAuth session
         session = OAuth1Session(
             consumer_key=client_id,
@@ -221,11 +287,11 @@ def test_connection(db: str, verbose: bool = False) -> bool:
             access_token_secret=session_secret,
         )
         session.headers.update({"User-Agent": f"mlstdb/{__version__}"})
-        
+
         # Make test request
         if verbose:
             info(f"\nRequesting:  {test_url}")
-        
+
         response = session.get(test_url)
         
         if verbose:

--- a/src/mlstdb/core/download.py
+++ b/src/mlstdb/core/download.py
@@ -61,7 +61,7 @@ def fetch_json(url, client_key, client_secret, session_token, session_secret,
                                  api_key=api_key)
 
     try:
-        response = session.get(url)
+        response = session.get(url, params={})
         if verbose:
             print(f"Response code: {response.status_code}, URL: {url}")
 
@@ -89,7 +89,7 @@ def fetch_json(url, client_key, client_secret, session_token, session_secret,
                     access_token_secret=new_session_secret,
                 )
                 retry_session.headers.update({"User-Agent": f"mlstdb/{__version__}"})
-                response = retry_session.get(url)
+                response = retry_session.get(url, params={})
                 if verbose:
                     print(f"Response code after token refresh: {response.status_code}, URL: {url}")
             # Raise for any remaining errors (e.g. 401 if not registered for this scheme)
@@ -119,7 +119,7 @@ def get_mlst_files(url: str, directory: str, client_key: str, client_secret: str
         info(f"Fetching MLST scheme from {url}...")
 
     try:
-        response = session.get(url)
+        response = session.get(url, params={})
         
         # Handle expired token (401)
         if response.status_code == 401:
@@ -144,7 +144,7 @@ def get_mlst_files(url: str, directory: str, client_key: str, client_secret: str
                     access_token_secret=session_secret,
                 )
                 session.headers.update({"User-Agent":  f"mlstdb/{__version__}"})
-                response = session.get(url)
+                response = session.get(url, params={})
             else:
                 error("Failed to refresh session token")
                 sys. exit(1)
@@ -214,7 +214,7 @@ def get_mlst_files(url: str, directory: str, client_key: str, client_secret: str
         loci_iter = tqdm(mlst_scheme['loci'], desc="Downloading loci", unit="locus") if show_progress else mlst_scheme['loci']
         for loci in loci_iter:
             name = loci. split('/')[-1]
-            loci_fasta = session.get(loci + '/alleles_fasta')
+            loci_fasta = session.get(loci + '/alleles_fasta', params={})
             loci_fasta.raise_for_status()
             loci_file_name = os.path.join(directory, name + '.tfa')
             with open(loci_file_name, 'wb') as f:
@@ -222,7 +222,7 @@ def get_mlst_files(url: str, directory: str, client_key: str, client_secret: str
 
         # Download profiles CSV
         profiles_url = url + '/profiles_csv'
-        profiles = session.get(profiles_url)
+        profiles = session.get(profiles_url, params={})
         profiles.raise_for_status()
         profiles_file_path = os.path.join(directory, f"{scheme_name}.txt")
         with open(profiles_file_path, 'w') as f:

--- a/src/mlstdb/core/download.py
+++ b/src/mlstdb/core/download.py
@@ -26,10 +26,13 @@ def get_db_type_from_url(url: str) -> str:
         raise ValueError(f"Unable to determine database type from URL: {url}")
 
 
-def create_session(client_key=None, client_secret=None, session_token=None, 
-                   session_secret=None, no_auth=False):
-    """Create a reusable HTTP session (OAuth or plain)."""
-    if no_auth:
+def create_session(client_key=None, client_secret=None, session_token=None,
+                   session_secret=None, no_auth=False, api_key=None):
+    """Create a reusable HTTP session (OAuth, API key, or plain)."""
+    if api_key:
+        session = requests.Session()
+        session.headers.update({"X-API-Key": api_key})
+    elif no_auth:
         session = requests.Session()
     else:
         session = OAuth1Session(
@@ -42,31 +45,34 @@ def create_session(client_key=None, client_secret=None, session_token=None,
     return session
 
 
-def fetch_json(url, client_key, client_secret, session_token, session_secret, 
-               verbose=False, session=None):
+def fetch_json(url, client_key, client_secret, session_token, session_secret,
+               verbose=False, session=None, api_key=None):
     """Fetch JSON from URL with optional OAuth authentication.
-    
+
     If a pre-built session is provided, it will be reused for connection pooling.
     Otherwise a new session is created per call (legacy behaviour).
     """
     if verbose:
         print(f"Fetching JSON from {url}")
-    
+
     # Use provided session or create a new one
     if session is None:
-        session = create_session(client_key, client_secret, session_token, session_secret)
+        session = create_session(client_key, client_secret, session_token, session_secret,
+                                 api_key=api_key)
 
     try:
         response = session.get(url)
         if verbose:
             print(f"Response code: {response.status_code}, URL: {url}")
-        
+
         if response.status_code == 404:
             print(f"Resource not found at URL: {url}")
             return None
-        
+
         # Handle 401 Unauthorised error - try once to refresh token
         if response.status_code == 401:
+            if api_key or not client_key:
+                response.raise_for_status()  # API keys/no-creds cannot use OAuth refresh
             # Determine which database we're working with
             db = get_db_type_from_url(url)
             
@@ -96,18 +102,18 @@ def fetch_json(url, client_key, client_secret, session_token, session_secret,
         raise
 
 
-def get_mlst_files(url:  str, directory: str, client_key: str, client_secret: str, 
-                   session_token: str, session_secret: str, scheme_name: str, 
+def get_mlst_files(url: str, directory: str, client_key: str, client_secret: str,
+                   session_token: str, session_secret: str, scheme_name: str,
                    verbose: bool = False, no_auth: bool = False,
-                   session=None, show_progress: bool = True) -> None:
+                   session=None, show_progress: bool = True, api_key=None) -> None:
     """Download MLST data and save them in the given directory.
-    
+
     If a pre-built session is provided, it will be reused for connection pooling.
     Set show_progress=False to suppress the per-locus tqdm bar (useful in parallel mode).
     """
     if session is None:
-        session = create_session(client_key, client_secret, session_token, 
-                                 session_secret, no_auth=no_auth)
+        session = create_session(client_key, client_secret, session_token,
+                                 session_secret, no_auth=no_auth, api_key=api_key)
 
     if verbose:
         info(f"Fetching MLST scheme from {url}...")
@@ -117,8 +123,8 @@ def get_mlst_files(url:  str, directory: str, client_key: str, client_secret: st
         
         # Handle expired token (401)
         if response.status_code == 401:
-            if no_auth:
-                response.raise_for_status()  # Let caller handle the error
+            if no_auth or api_key or not client_key:
+                response.raise_for_status()  # Let caller handle; no OAuth refresh available
             if verbose:
                 info("Session token expired, attempting to refresh...")
             
@@ -235,12 +241,12 @@ def get_mlst_files(url:  str, directory: str, client_key: str, client_secret: st
             error(f"Resource not found at URL: {url}")
         raise
 
-def fetch_resources(base_uri, client_key, client_secret, session_token, session_secret, 
-                    verbose=False, session=None):
+def fetch_resources(base_uri, client_key, client_secret, session_token, session_secret,
+                    verbose=False, session=None, api_key=None):
     if verbose:
         print(f"Fetching resources from {base_uri}")
-    return fetch_json(base_uri, client_key, client_secret, session_token, session_secret, 
-                      verbose, session=session)
+    return fetch_json(base_uri, client_key, client_secret, session_token, session_secret,
+                      verbose, session=session, api_key=api_key)
 
 def clear_file(file_path):
     """Clear the contents of a file or create it if it doesn't exist."""

--- a/tests/test_core/test_auth.py
+++ b/tests/test_core/test_auth.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import patch
-from mlstdb.core.auth import register_tokens, setup_client_credentials
+from mlstdb.core.auth import register_tokens, setup_client_credentials, setup_api_key, retrieve_api_key
 from pathlib import Path
 
 def test_setup_client_credentials(tmp_path):
@@ -19,3 +19,45 @@ def test_setup_client_credentials(tmp_path):
             content = f.read()
             assert "123456" * 4 in content  # 24-char client ID
             assert "1234567" * 6 in content  # 42-char secret
+
+
+def test_setup_api_key(tmp_path):
+    config_dir = tmp_path / ".config" / "mlstdb"
+    config_dir.mkdir(parents=True)
+
+    with patch('mlstdb.core.auth.get_config_dir', return_value=config_dir), \
+         patch('click.prompt', return_value='my-test-api-key-abc123'):
+        result = setup_api_key('pubmlst')
+
+    assert result == 'my-test-api-key-abc123'
+    api_keys_file = config_dir / 'api_keys'
+    assert api_keys_file.exists()
+    import stat
+    assert oct(stat.S_IMODE(api_keys_file.stat().st_mode)) == '0o600'
+    with open(api_keys_file) as f:
+        content = f.read()
+    assert 'my-test-api-key-abc123' in content
+    assert '[pubmlst]' in content
+
+
+def test_retrieve_api_key_found(tmp_path):
+    config_dir = tmp_path / ".config" / "mlstdb"
+    config_dir.mkdir(parents=True)
+
+    api_keys_file = config_dir / 'api_keys'
+    api_keys_file.write_text('[pubmlst]\napi_key = abc-xyz-123\n')
+
+    with patch('mlstdb.core.auth.get_config_dir', return_value=config_dir):
+        key = retrieve_api_key('pubmlst')
+
+    assert key == 'abc-xyz-123'
+
+
+def test_retrieve_api_key_missing(tmp_path):
+    config_dir = tmp_path / ".config" / "mlstdb"
+    config_dir.mkdir(parents=True)
+
+    with patch('mlstdb.core.auth.get_config_dir', return_value=config_dir):
+        key = retrieve_api_key('pubmlst')
+
+    assert key is None

--- a/tests/test_core/test_download.py
+++ b/tests/test_core/test_download.py
@@ -1,0 +1,20 @@
+import pytest
+from mlstdb.core.download import create_session
+
+
+def test_create_session_api_key():
+    session = create_session(api_key='test-key-abc')
+    assert session.headers.get('X-API-Key') == 'test-key-abc'
+    assert 'mlstdb/' in session.headers.get('User-Agent', '')
+
+
+def test_create_session_no_auth():
+    session = create_session(no_auth=True)
+    assert 'X-API-Key' not in session.headers
+    assert 'mlstdb/' in session.headers.get('User-Agent', '')
+
+
+def test_create_session_api_key_takes_precedence_over_no_auth():
+    """api_key should win when both api_key and no_auth are set."""
+    session = create_session(no_auth=True, api_key='should-win')
+    assert session.headers.get('X-API-Key') == 'should-win'


### PR DESCRIPTION
This PR adds personal API key support for BIGSdb ≥ v1.53.0 and fixes the `TypeError: argument of type 'NoneType' is not iterable` crash reported by users on Rocky Linux and WSL2 (#35).

---

## Changes

### New Feature: Personal API Key (`--api-key`)

BIGSdb v1.53.0 (PubMLST since May 2026) supports personal API keys as a simpler OAuth alternative.

- `mlstdb connect --db pubmlst --api-key` — prompts for a key, stores it in `~/.config/mlstdb/api_keys` 
- `mlstdb update` and `mlstdb fetch` automatically prefer the stored API key over OAuth session tokens
- No browser step, no verification code, no clock-sync required
- New `setup_api_key()` / `retrieve_api_key()` in `mlstdb.core.auth`
- `create_session()` extended with `api_key=` parameter

### Bug Fixes

**Fix #35 — `NoneType is not iterable` on Rocky Linux / WSL2**

rauth 0.7.3 `_parse_optional_params` does `req_kwargs.get('params')` without a default. When `params=` is not passed to `OAuth1Session.get()`, this returns `None`, and `if oauth_param in None` raises `TypeError` before the HTTP request is even sent. The session token step in `register_tokens()` was the only OAuth step that did not pass an explicit `params=` dict.

Fix: pass `params={}` to every bare `OAuth1Session.get()` call in `auth.py` and `download.py`.

**Safe error message parsing**

Replaced all bare `r.json()['message']` calls with a new `_parse_error_message()` helper that gracefully handles non-JSON responses (HTML redirect pages, empty bodies).

**Clock-skew guidance**

`mlstdb connect` now detects a `timestamp more than 600 seconds` OAuth error and prints OS-specific sync instructions.

---

## Tests

- 15/15 existing tests pass
- 3 new tests for `setup_api_key`, `retrieve_api_key` (found/missing)
- 3 new tests for `create_session` with API key priority logic

## Closes / References

- Address #35